### PR TITLE
more specific definition of relationship between .janno and .fam files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The `.janno` file is a tab-separated text file with a header line that holds a c
 - A `.janno` file must have all of these columns in exactly this order with exactly these column names. 
 - If information is unknown or a variable does not apply for a certain sample, then the respective cell(s) can be filled with the NULL value `n/a`. Ideally, a `.janno` file should have the least number of n/a-values possible.
 - The order of the samples (rows) in the `.janno` file must be equal to the order in the files that hold the genetic data.
+- The values in the columns **Individual_ID** and **Group_Name** must be equal to the terms used in the first and second column of the `.fam` file.
 - Multiple columns of the `.janno` file are list columns that hold multiple values (either strings or numerics) separated by `;`
 
 ### The `X.bed`, `X.bim`, `X.fam` files [mandatory]

--- a/janno_columns.tsv
+++ b/janno_columns.tsv
@@ -1,5 +1,5 @@
 janno_column_name	description	column_type	choice_options	mandatory	unique	range_lower	range_upper
-Individual_ID	id as defined by the genetics laboratory, needs to be unique (e.g. I1234, BOT001), if multiple datasets exist for the same individual different IDs are required (e.g. loschbour_snpAD)	String		TRUE	TRUE		
+Individual_ID	id as defined by the genetics laboratory, needs to be unique (e.g. I1234, BOT001), needs to fit to the values in the poseidon package .fam file, if multiple datasets exist for the same individual different IDs are required (e.g. loschbour_snpAD)	String		TRUE	TRUE		
 Collection_ID	id as defined by the provider/owner of a sample (e.g. grave 40 skeleton 2)	String		FALSE	FALSE		
 Source_Tissue	skeletal/tissue/source elements, multiple values separated by ; in case of merged libraries	String list		FALSE	FALSE		
 Country	present-day political country	String		FALSE	FALSE		
@@ -17,7 +17,7 @@ Date_Type	"""C14"" if directly from the individual, ""contextual"" if based on a
 No_of_Libraries	number of libraries	Integer		FALSE	FALSE		
 Data_Type	specifics of data generation method	String choice	Shotgun;1240K;OtherCapture;ReferenceGenome	FALSE	FALSE		
 Genotype_Ploidy	ploidy of the genotypes	String choice	diploid;haploid	FALSE	FALSE		
-Group_Name	ideally Eisenmann rule + underscore flags, e.g. to annotate relatives or outliers or low coverage, multiple entries separated by ; to accommodate different labels, in case of multiple entries the first one must equal the group name in the .fam file	String list		TRUE	FALSE		
+Group_Name	ideally Eisenmann rule + underscore flags, e.g. to annotate relatives or outliers or low coverage, multiple entries separated by ; to accommodate different labels, value must equal the group name in the .fam file (in case of multiple entries the first one)	String list		TRUE	FALSE		
 Genetic_Sex	"""F"", ""M"" or ""U"" because eigenstrat and plink formats only support these three. Edge cases (XXY, XYY, X0) are undefined and should be grouped as F, M or U, with a note added"	Char choice	F;M;U	TRUE	FALSE		
 Nr_autosomal_SNPs	number of autosomal SNPs covered for 1240K capture or SG data pulldown	Integer		FALSE	FALSE		
 Coverage_1240K	average X-fold coverage across 1240K SNP sites after quality filtering (internal data), NOT the % SNPs of 1.2M possible	Float		FALSE	FALSE		


### PR DESCRIPTION
@kaypruefer recently highlighted a problem in information attribution between context data and actual genetic data:

> In these publications, the order of the entries in the .janno file does not match the order in the .ind files. Unfortunately, one cannot simply fix this by matching the identifiers, since the id's in the .ind can be different from those in the first-column of the .janno files

I therefore suggest to secure this critical connection point with not just equality of sample order, but also identical individual and group names in `.janno` and `.fam`.