### PR TITLE
Poseidon yml definition

### DIFF
--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -1,0 +1,15 @@
+field	level	parent	description	type	format	mandatory	unique
+poseidonVersion	0			String		TRUE	TRUE
+title	0			String		TRUE	TRUE
+description	0			String		FALSE	TRUE
+contributor	0			Array		TRUE	TRUE
+name	1	contributor		String		TRUE	FALSE
+email	1	contributor		String	Email	TRUE	FALSE
+lastModified	0			Date	YYYY-MM-DD	FALSE	TRUE
+bibFile	0			String	Path	FALSE	TRUE
+genotypeData	0			Array	Path	TRUE	TRUE
+format	1	genotypeData		String		TRUE	TRUE
+genoFile	1	genotypeData		String	Path	TRUE	TRUE
+snpFile	1	genotypeData		String	Path	TRUE	TRUE
+indFile	1	genotypeData		String	Path	TRUE	TRUE
+jannoFile	0			String	Path	TRUE	TRUE

--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -1,15 +1,15 @@
 field	level	parent	description	type	format	mandatory	unique
-poseidonVersion	0			String		TRUE	TRUE
-title	0			String		TRUE	TRUE
-description	0			String		FALSE	TRUE
-contributor	0			Array		TRUE	TRUE
-name	1	contributor		String		TRUE	FALSE
-email	1	contributor		String	Email	TRUE	FALSE
-lastModified	0			Date	YYYY-MM-DD	FALSE	TRUE
-bibFile	0			String	Path	FALSE	TRUE
-genotypeData	0			Array	Path	TRUE	TRUE
-format	1	genotypeData		String		TRUE	TRUE
-genoFile	1	genotypeData		String	Path	TRUE	TRUE
-snpFile	1	genotypeData		String	Path	TRUE	TRUE
-indFile	1	genotypeData		String	Path	TRUE	TRUE
-jannoFile	0			String	Path	TRUE	TRUE
+poseidonVersion	0		poseidon v.2 package version (e.g. 2.0.1)	String		TRUE	TRUE
+title	0		title of the package	String		TRUE	TRUE
+description	0		some descriptive words about the package	String		FALSE	TRUE
+contributor	0		list of contributors to the package (not the data producer/publication author, but the poseidon package creator), each with name and email	Array		TRUE	TRUE
+name	1	contributor	name of one contributor	String		TRUE	FALSE
+email	1	contributor	email of one contributor (must be a valid email address)	String	Email	TRUE	FALSE
+lastModified	0		date of last modification of the poseidon package	Date	YYYY-MM-DD	FALSE	TRUE
+bibFile	0		file name (.bib)	String	Path	FALSE	TRUE
+genotypeData	0		genotype file name section			TRUE	TRUE
+format	1	genotypeData	file format definition, only allows PLINK right now	String		TRUE	TRUE
+genoFile	1	genotypeData	file name (.bed)	String	Path	TRUE	TRUE
+snpFile	1	genotypeData	file name (.bim)	String	Path	TRUE	TRUE
+indFile	1	genotypeData	file name (.fam	String	Path	TRUE	TRUE
+jannoFile	0		file name (.janno)	String	Path	TRUE	TRUE

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Switzerland_LNBA_Roswita/LITERATURE.bib
 
 The `POSEIDON.yml` file lists metainformation in a standardized, machine-readable format.
 
+- The `POSEIDON.yml` file must be a valid [YAML file](https://yaml.org/).
+- The fields of the `POSEIDON.yml` file are documented in the [POSEIDON_yml_fields.tsv file](https://github.com/poseidon-framework/poseidon2-schema/blob/master/POSEIDON_yml_fields.tsv) in this repository.
+
 Example:
 
 ```


### PR DESCRIPTION
The `POSEIDON.yml` is only defined with an example so far. I suggest to extend that with a definition table similar to the one we crafted for the `.janno` file