### PR TITLE
Poseidon v2.6.0

### DIFF
--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -7,7 +7,7 @@ name	1	contributor	name of one contributor	String		TRUE
 email	1	contributor	email of one contributor (must be a valid email address)	String	Email	TRUE
 orcid	1	contributor	orcid of one contributor (must be a valid orcid)	String	ORCID	FALSE
 packageVersion	0		version of the package (should be changed/incremented when the package is changed)	String		TRUE
-lastModified	0		date of last modification of the Poseidon package (should be updated when the package is changed)	Date	YYYY-MM-DD	TRUE
+lastModified	0		date of last modification of the Poseidon package (should be updated when the package is changed)	Date	YYYY-MM-DD	FALSE
 genotypeData	0		genotype file name section			TRUE
 format	1	genotypeData	file format definition, allows EIGENSTRAT and PLINK	String		TRUE
 genoFile	1	genotypeData	relative path to genoFile	String	Path	TRUE

--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -19,6 +19,7 @@ indFileChkSum	1	genotypeData	md5 checksum of the indFile	String		FALSE
 snpSet	1	genotypeData	Can be either 1240K, HumanOrigins or Other depending on the list of SNPs used	String	(1240K|HumanOrigins|Other)	FALSE
 jannoFile	0		relative path to jannoFile	String	Path	FALSE
 jannoFileChkSum	1	genotypeData	md5 checksum of the jannoFile	String		FALSE
+sequencingSourceFile	0		relative path to sequencingSourceFile	String	Path	FALSE
 bibFile	0		relative path to bibFile	String	Path	FALSE
 bibFileChkSum	1	genotypeData	md5 checksum of the bibFile	String		FALSE
 readmeFile	0		relative path to readmeFile	String	Path	FALSE

--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -2,9 +2,10 @@ field	level	parent	description	type	format	mandatory
 poseidonVersion	0		Poseidon package format version (e.g. 2.0.1)	String		TRUE
 title	0		title of the package	String		TRUE
 description	0		some descriptive words about the package	String		FALSE
-contributor	0		list of contributors to the package (not the data producer/publication author, but the Poseidon package creator), each with name and email	Array		TRUE
+contributor	0		list of contributors to the package (not publication author, but the Poseidon package creator)	Array		FALSE
 name	1	contributor	name of one contributor	String		TRUE
 email	1	contributor	email of one contributor (must be a valid email address)	String	Email	TRUE
+orcid	1	contributor	orcid of one contributor (must be a valid orcid)	String	ORCID	FALSE
 packageVersion	0		version of the package (should be changed/incremented when the package is changed)	String		TRUE
 lastModified	0		date of last modification of the Poseidon package (should be updated when the package is changed)	Date	YYYY-MM-DD	TRUE
 genotypeData	0		genotype file name section			TRUE

--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -1,24 +1,24 @@
-field	level	parent	description	type	format	mandatory	unique
-poseidonVersion	0		Poseidon package format version (e.g. 2.0.1)	String		TRUE	TRUE
-title	0		title of the package	String		TRUE	TRUE
-description	0		some descriptive words about the package	String		FALSE	TRUE
-contributor	0		list of contributors to the package (not the data producer/publication author, but the Poseidon package creator), each with name and email	Array		TRUE	TRUE
-name	1	contributor	name of one contributor	String		TRUE	FALSE
-email	1	contributor	email of one contributor (must be a valid email address)	String	Email	TRUE	FALSE
-packageVersion	0		version of the package (should be changed/incremented when the package is changed)	String		TRUE	TRUE
-lastModified	0		date of last modification of the Poseidon package (should be updated when the package is changed)	Date	YYYY-MM-DD	TRUE	TRUE
-genotypeData	0		genotype file name section			TRUE	TRUE
-format	1	genotypeData	file format definition, allows EIGENSTRAT and PLINK	String		TRUE	TRUE
-genoFile	1	genotypeData	relative path to genoFile	String	Path	TRUE	TRUE
-genoFileChkSum	1	genotypeData	md5 checksum of the genoFile	String		FALSE	TRUE
-snpFile	1	genotypeData	relative path to snpFile	String	Path	TRUE	TRUE
-snpFileChkSum	1	genotypeData	md5 checksum of the snpFile	String		FALSE	TRUE
-indFile	1	genotypeData	relative path to indFile	String	Path	TRUE	TRUE
-indFileChkSum	1	genotypeData	md5 checksum of the indFile	String		FALSE	TRUE
-snpSet	1	genotypeData	Can be either 1240K, HumanOrigins or Other depending on the list of SNPs used	String	(1240K|HumanOrigins|Other)	FALSE	FALSE
-jannoFile	0		relative path to jannoFile	String	Path	FALSE	TRUE
-jannoFileChkSum	1	genotypeData	md5 checksum of the jannoFile	String		FALSE	TRUE
-bibFile	0		relative path to bibFile	String	Path	FALSE	TRUE
-bibFileChkSum	1	genotypeData	md5 checksum of the bibFile	String		FALSE	TRUE
-readmeFile	0		relative path to readmeFile	String	Path	FALSE	TRUE
-changelogFile	0		relative path to changelogFile	String	Path	FALSE	TRUE
+field	level	parent	description	type	format	mandatory
+poseidonVersion	0		Poseidon package format version (e.g. 2.0.1)	String		TRUE
+title	0		title of the package	String		TRUE
+description	0		some descriptive words about the package	String		FALSE
+contributor	0		list of contributors to the package (not the data producer/publication author, but the Poseidon package creator), each with name and email	Array		TRUE
+name	1	contributor	name of one contributor	String		TRUE
+email	1	contributor	email of one contributor (must be a valid email address)	String	Email	TRUE
+packageVersion	0		version of the package (should be changed/incremented when the package is changed)	String		TRUE
+lastModified	0		date of last modification of the Poseidon package (should be updated when the package is changed)	Date	YYYY-MM-DD	TRUE
+genotypeData	0		genotype file name section			TRUE
+format	1	genotypeData	file format definition, allows EIGENSTRAT and PLINK	String		TRUE
+genoFile	1	genotypeData	relative path to genoFile	String	Path	TRUE
+genoFileChkSum	1	genotypeData	md5 checksum of the genoFile	String		FALSE
+snpFile	1	genotypeData	relative path to snpFile	String	Path	TRUE
+snpFileChkSum	1	genotypeData	md5 checksum of the snpFile	String		FALSE
+indFile	1	genotypeData	relative path to indFile	String	Path	TRUE
+indFileChkSum	1	genotypeData	md5 checksum of the indFile	String		FALSE
+snpSet	1	genotypeData	Can be either 1240K, HumanOrigins or Other depending on the list of SNPs used	String	(1240K|HumanOrigins|Other)	FALSE
+jannoFile	0		relative path to jannoFile	String	Path	FALSE
+jannoFileChkSum	1	genotypeData	md5 checksum of the jannoFile	String		FALSE
+bibFile	0		relative path to bibFile	String	Path	FALSE
+bibFileChkSum	1	genotypeData	md5 checksum of the bibFile	String		FALSE
+readmeFile	0		relative path to readmeFile	String	Path	FALSE
+changelogFile	0		relative path to changelogFile	String	Path	FALSE

--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -19,7 +19,6 @@ indFileChkSum	1	genotypeData	md5 checksum of the indFile	String		FALSE
 snpSet	1	genotypeData	Can be either 1240K, HumanOrigins or Other depending on the list of SNPs used	String	(1240K|HumanOrigins|Other)	FALSE
 jannoFile	0		relative path to jannoFile	String	Path	FALSE
 jannoFileChkSum	1	genotypeData	md5 checksum of the jannoFile	String		FALSE
-sequencingSourceFile	0		relative path to sequencingSourceFile	String	Path	FALSE
 bibFile	0		relative path to bibFile	String	Path	FALSE
 bibFileChkSum	1	genotypeData	md5 checksum of the bibFile	String		FALSE
 readmeFile	0		relative path to readmeFile	String	Path	FALSE

--- a/janno_columns.tsv
+++ b/janno_columns.tsv
@@ -25,7 +25,7 @@ MT_Haplogroup	mitochondrial haplogroup after phylotree.org as reported by Haplof
 Y_Haplogroup	Y-chromosome haplogroup reported as published, for internal data, please follow syntax with main branch + most terminal derived Y-SNP (e.g. R1b-P312)	String	FALSE	FALSE	FALSE				FALSE	FALSE
 Source_Tissue	skeletal/tissue/source elements, specific bone name should be reported with an underscore (e.g. bone_phalanx), multiple values separated by ; in case of multiple libraries	String	TRUE	FALSE	FALSE				FALSE	FALSE
 Nr_Libraries	number of libraries	Integer	FALSE	FALSE	FALSE				FALSE	FALSE
-Capture_Type	specifics of data generation method, multiple values separated by ;	String	TRUE	TRUE	FALSE	Shotgun;1240K;OtherCapture;ReferenceGenome			FALSE	FALSE
+Capture_Type	specifics of data generation method, multiple values separated by ;	String	TRUE	TRUE	FALSE	Shotgun;1240K;ArborComplete;ArborPrimePlus;ArborAncestralPlus;TwistAncientDNA;OtherCapture;ReferenceGenome			FALSE	FALSE
 UDG 	“mixed” in case multiple libraries with different UDG treatment were merged	String	FALSE	TRUE	FALSE	minus;half;plus;mixed			FALSE	FALSE
 Library_Built	“ds” for double stranded, “ss” for single stranded, “mixed” in case multiple libraries with different protocols were merged	String	FALSE	TRUE	FALSE	ds;ss;other			FALSE	FALSE
 Genotype_Ploidy	ploidy of the genotypes	String	FALSE	TRUE	FALSE	diploid;haploid			FALSE	FALSE


### PR DESCRIPTION
I started to collect suggestions for the next release here. The last update was focused on the .janno file and pretty massive. I would like to concentrate on the POSEIDON.yml file for 2.6.0 -- and ideally also keep the number and complexity of changes lower.

What I changed so far:

- Removed the `unique` column from `POSEIDON_yml_fields.tsv`. I don't remember what it was supposed to encode originally and I think it's not necessary any more.
- Made the `contributor` field optional. We should of course insist on it for the published_data repository, but for personal packages it's tedious to enter this information. It's also unnecessarily verbose when Poseidon is used as part of automated pipelines.
- Added the optional subfield `ORCID` to the `contributor` field. A unique identifier for authors is very valuable. Emails often change rather quickly.

Added later: 

- added new capture types to janno schema