### PR TITLE
Clarification for the meaning of the Date_Type column

### DIFF
--- a/janno_columns.tsv
+++ b/janno_columns.tsv
@@ -14,10 +14,10 @@ Location	unspecified location information like administrative or topographic reg
 Site	site name	String	FALSE	FALSE	FALSE				FALSE	FALSE
 Latitude	latitude with up to 5 places after the decimal point	Float	FALSE	FALSE	TRUE		-90	90	FALSE	FALSE
 Longitude	longitude with up to 5 places after the decimal point	Float	FALSE	FALSE	TRUE		-180	180	FALSE	FALSE
-Date_Type	“C14“ if directly from the individual, “contextual“ if based on archaeology or other C14 dates from the site, “modern” for present-day individuals	String	FALSE	TRUE	FALSE	C14;contextual;modern			FALSE	FALSE
+Date_Type	“C14“ if there is a set of radiocarbon dates in the columns Date_C14_Labnr, Date_C14_Uncal_BP and Date_C14_Uncal_BP_Err whose post-calibration probability distribution is a meaningful prior for the individual’s year of death, “contextual“ for any other age information only given in Date_BC_AD_Start, Date_BC_AD_Median and Date_BC_AD_Stop, “modern” for present-day individuals	String	FALSE	TRUE	FALSE	C14;contextual;modern			FALSE	FALSE
 Date_C14_Labnr	labnr of C14 date, multiple values separated by ; in case of multiple dates	String	TRUE	FALSE	FALSE				FALSE	FALSE
-Date_C14_Uncal_BP	uncalibrated years BP (as in before 1950AD), as reported by C14 labs, multiple values separated by ; in the same order as Date_C14_Labnr in case of multiple dates	Integer	TRUE	FALSE	TRUE		0	Inf	FALSE	FALSE
-Date_C14_Uncal_BP_Err	standard deviation (1 sigma ±), as reported by C14 labs, multiple values separated by ; in the same order as Date_C14_Labnr in case of multiple dates	Integer	TRUE	FALSE	TRUE		0	Inf	FALSE	FALSE
+Date_C14_Uncal_BP	uncalibrated years BP (as in before 1950AD), as reported by C14 labs, multiple values separated by ; in the same order as Date_C14_Labnr in case of multiple dates, only relevant if Date_Type is “C14”	Integer	TRUE	FALSE	TRUE		0	Inf	FALSE	FALSE
+Date_C14_Uncal_BP_Err	standard deviation (1 sigma ±), as reported by C14 labs, multiple values separated by ; in the same order as Date_C14_Labnr in case of multiple dates, only relevant if Date_Type is “C14”	Integer	TRUE	FALSE	TRUE		0	Inf	FALSE	FALSE
 Date_BC_AD_Start	lower (older) bound for the age, negative numbers for BC, positive numbers for AD, in case of C14 dates 95% interval post calibration, 2000 for modern samples	Integer	FALSE	FALSE	TRUE		-Inf	2050	FALSE	FALSE
 Date_BC_AD_Median	calibrated median age for C14 dates, or simple mid-points for archaeological intervals, 2000 for modern samples	Integer	FALSE	FALSE	TRUE		-Inf	2050	FALSE	FALSE
 Date_BC_AD_Stop	upper (more recent) bound for the age, negative numbers for BC, positive numbers for AD, in case of C14 dates 95% interval post calibration, 2000 for modern samples	Integer	FALSE	FALSE	TRUE		-Inf	2050	FALSE	FALSE


### PR DESCRIPTION
After some confusion about the age information columns (see e.g. https://github.com/poseidon-framework/community-archive/pull/146#issuecomment-1820583405 and https://github.com/poseidon-framework/poseidon-hs/pull/283#issuecomment-1848975419) I would like to suggest a clarification for the description in schema version 2.7.1.

Note the emphasis I put on usability for derived, computational analysis. My idea is as follows: If the `Date_Type` field is set to `C14`, then the date(s) in `Date_C14_Uncal_BP` and `Date_C14_Uncal_BP_Err` should be directly useful for derived modelling. If, on the other hand, the age of a sample is only vaguely informed by a radiocarbon date from a stratigraphically related layer, then this is contextual (!) information that does not have to be listed in the .janno file, but only indirectly feeds into the contextual age columns `Date_BC_AD_Start`, `Date_BC_AD_Median` and `Date_BC_AD_Stop`.