### PR TITLE
Small improvements to the 2.7.1 schema text

### DIFF
--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -1,27 +1,27 @@
 field	level	parent	description	type	format	mandatory
-poseidonVersion	0		Poseidon package format version (e.g. 2.0.1). Should strictly follow the format X.Y.Z	String		TRUE
+poseidonVersion	0		Poseidon package format version (e.g. 2.0.1)	String	X.Y.Z	TRUE
 title	0		title of the package	String		TRUE
-description	0		some descriptive words about the package	String		FALSE
-contributor	0		list of contributors to the package (not publication author, but the Poseidon package creator)	Array		FALSE
+description	0		description of the package (one or multiple sentences)	String		FALSE
+contributor	0		list of contributors to the package (not the publication author, but the Poseidon package creator)	Array		FALSE
 name	1	contributor	name of one contributor	String		TRUE
-email	1	contributor	email of one contributor (must be a valid email address)	String	Email	TRUE
-orcid	1	contributor	orcid of one contributor (must be a valid orcid)	String	ORCID	FALSE
-packageVersion	0		version of the package (should be changed/incremented when the package is changed). Should strictly follow the format X.Y.Z	String		TRUE
-lastModified	0		date of last modification of the Poseidon package (should be updated when the package is changed)	Date	YYYY-MM-DD	FALSE
-genotypeData	0		genotype file name section			TRUE
-format	1	genotypeData	file format definition, allows EIGENSTRAT and PLINK	String		TRUE
-genoFile	1	genotypeData	relative path to genoFile	String	Path	TRUE
-genoFileChkSum	1	genotypeData	md5 checksum of the genoFile	String		FALSE
-snpFile	1	genotypeData	relative path to snpFile	String	Path	TRUE
-snpFileChkSum	1	genotypeData	md5 checksum of the snpFile	String		FALSE
-indFile	1	genotypeData	relative path to indFile	String	Path	TRUE
-indFileChkSum	1	genotypeData	md5 checksum of the indFile	String		FALSE
-snpSet	1	genotypeData	Can be either 1240K, HumanOrigins or Other depending on the list of SNPs used	String	(1240K|HumanOrigins|Other)	FALSE
-jannoFile	0		relative path to jannoFile	String	Path	FALSE
-jannoFileChkSum	0		md5 checksum of the jannoFile	String		FALSE
-sequencingSourceFile	0		relative path to sequencingSourceFile	String	Path	FALSE
-sequencingSourceFileChkSum	0		md5 checksum of the sequencingSourceFile	String		FALSE
-bibFile	0		relative path to bibFile	String	Path	FALSE
-bibFileChkSum	0		md5 checksum of the bibFile	String		FALSE
-readmeFile	0		relative path to readmeFile	String	Path	FALSE
-changelogFile	0		relative path to changelogFile	String	Path	FALSE
+email	1	contributor	email of one contributor	String	Email	TRUE
+orcid	1	contributor	orcid of one contributor	String	ORCID	FALSE
+packageVersion	0		package version (should be changed/incremented when the package is changed)	String	X.Y.Z	TRUE
+lastModified	0		date of last modification of the package (should be updated when the package is changed)	Date	YYYY-MM-DD	FALSE
+genotypeData	0		genotype data section			TRUE
+format	1	genotypeData	genotype data file format	String	EIGENSTRAT;PLINK	TRUE
+genoFile	1	genotypeData	relative path to the geno file	String	Path	TRUE
+genoFileChkSum	1	genotypeData	md5 checksum of the geno file	String	md5 hash	FALSE
+snpFile	1	genotypeData	relative path to the snp file	String	Path	TRUE
+snpFileChkSum	1	genotypeData	md5 checksum of the snp file	String	md5 hash	FALSE
+indFile	1	genotypeData	relative path to the ind file	String	Path	TRUE
+indFileChkSum	1	genotypeData	md5 checksum of the ind file	String	md5 hash	FALSE
+snpSet	1	genotypeData	SNP set in the genotype data	String	1240K;HumanOrigins;Other	FALSE
+jannoFile	0		relative path to the .janno file	String	Path	FALSE
+jannoFileChkSum	0		md5 checksum of the .janno file	String	md5 hash	FALSE
+sequencingSourceFile	0		relative path to the .ssf file	String	Path	FALSE
+sequencingSourceFileChkSum	0		md5 checksum of the .ssf file	String	md5 hash	FALSE
+bibFile	0		relative path to the .bib file	String	Path	FALSE
+bibFileChkSum	0		md5 checksum of the .bib file	String	md5 hash	FALSE
+readmeFile	0		relative path to the README file	String	Path	FALSE
+changelogFile	0		relative path to the CHANGELOG file	String	Path	FALSE

--- a/README.md
+++ b/README.md
@@ -183,10 +183,11 @@ A markdown file to document changes in the history of a package.
 Example:
 
 ```
-- V 1.2.0: Fixed a spelling mistake in the site name "Hosenacker"->"Rosenacker"
-- V 1.1.1: Added mtDNA contamination estimation to .janno file
-- V 1.1.0: The authors of @Gassenhauer_2021 made some previously restricted samples for their publication available later and we added them
-- V 1.0.0: Creation of the package
+- V 1.1.1: Fixed a spelling mistake in one site name: "Hosenacker" -> "Rosenacker"
+- V 1.1.0: Added mtDNA contamination estimation to the .janno file
+- V 1.0.0: Added spatial coordinates and age information to the .janno file and finalized a first stable version of the package
+- V 0.2.0: Added previously restricted sample L1337
+- V 0.1.0: Creation of the package
 ```
 
 The structure with `- V X.X.X:` at the beginning of each line is not mandatory, but SHOULD be followed for reasons of interoperability.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This standard defines the core components of the Poseidon package. Further detai
 
 A changelog for this standard is available on the website [here](https://poseidon-framework.github.io/#/changelog).
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
 ### The Poseidon package structure
 
 A Poseidon package stores genotype data with context information for DNA samples from (ancient) (human) individuals. Packages are defined by the POSEIDON.yml file, which holds relative paths to all other files in a package.
@@ -20,7 +22,7 @@ It SHOULD additionally contain:
 - A `.janno` file to store context information on spatiotemporal origin or sample quality
 - A `.bib` file for literature references
 
-It CAN also contain:
+It MAY also contain:
 
 - A `README.md` file for arbitrary, additional context information
 - A `CHANGELOG.md` file to document changes to the package
@@ -130,11 +132,11 @@ In addition to these files (and optionally their checksums), the POSEIDON.yml fi
 The `.janno` file is a tab-separated text file with a header line. It holds context information (variables/columns) for each sample (objects/rows) in a package.
 
 - A set of strictly defined core variables (defined by column name) and their possible content are documented here: [janno_columns.tsv](https://github.com/poseidon-framework/poseidon-schema/blob/master/janno_columns.tsv)
-- A `.janno` file CAN have all of these core variables, or only a subset of them.
+- A `.janno` file MAY have all of these core variables, or only a subset of them.
 - Only three columns MUST be present to make the file valid: **Poseidon_ID**, **Group_Name** and **Genetic_Sex**
-- Arbitrary columns not defined here CAN be added as long as their column names do not clash with the defined ones.
+- Arbitrary columns not defined here MAY be added as long as their column names do not clash with the defined ones.
 - The column order is irrelevant.
-- If information is unknown or a variable does not apply for a certain sample, then the respective cell(s) can be filled with the NULL value `n/a` or simply an empty string.
+- If information is unknown or a variable does not apply for a certain sample, then the respective cell(s) MAY be filled with the NULL value `n/a` or simply an empty string.
 - The order of the samples (rows) in the `.janno` file MUST be equal to the order in the genetic data files (`.ind`, `.fam`) in the package.
 - The values in the columns **Poseidon_ID**, **Group_Name** and **Genetic_Sex** MUST be equal to the terms used in the genetic data files (`.ind`, `.fam`).
 - Multiple predefined columns of the `.janno` file are list columns that can hold multiple values (either strings or numerics) separated by `;`.
@@ -196,10 +198,10 @@ The structure with `- V X.X.X:` at the beginning of each line is not mandatory, 
 The `.ssf` file is another tab-separated text file with a header line. It stores sequencing source data, so metainformation about the raw sequencing data behind the genotypes in a Poseidon package. The primary entities in this table are sequencing entities, typically corresponding to DNA libraries or even multiple runs/lanes of the same library.
 
 - The predefined columns are specified here: [ssf_columns.tsv](https://github.com/poseidon-framework/poseidon-schema/blob/master/ssf_columns.tsv)
-- All columns of this schema are optional, so a `.ssf` CAN have all of these core variables, only a subset of them, or even none. It SHOULD have a `poseidon_IDs` column, though, to link the sequencing entities to the Poseidon package.
+- All columns of this schema are optional, so a `.ssf` MAY have all of these core variables, only a subset of them, or even none. It SHOULD have a `poseidon_IDs` column, though, to link the sequencing entities to the Poseidon package.
 - The link to the individuals listed in the `.janno`-file (and therefore to the entire Poseidon package) is made through a many-to-many foreign-key relationship between the .janno column `Poseidon_ID` and the .ssf column `poseidon_IDs`. That means each entry in the .janno file can be linked to many rows in the .ssf file and vice versa.
-- As in the `.janno` file arbitrary columns not defined here CAN be added to the `.ssf` file as long as their column names do not clash with the defined ones.
+- As in the `.janno` file arbitrary columns not defined here MAY be added to the `.ssf` file as long as their column names do not clash with the defined ones.
 - The order of columns and rows is irrelevant.
-- If information is unknown or a variable does not apply, then the respective cell(s) can be filled with the NULL value `n/a` or simply an empty string.
+- If information is unknown or a variable does not apply, then the respective cell(s) MAY be filled with the NULL value `n/a` or simply an empty string.
 - Multiple predefined columns of the `.ssf` file are list columns that can hold multiple values (either strings or numerics) separated by `;`.
 - The decimal separator for all floating point numbers MUST be `.`.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The `.janno` file is a tab-separated text file with a header line. It holds cont
 - Only three columns MUST be present to make the file valid: **Poseidon_ID**, **Group_Name** and **Genetic_Sex**
 - Arbitrary columns not defined here MAY be added as long as their column names do not clash with the defined ones.
 - The column order is irrelevant.
-- If information is unknown or a variable does not apply for a certain sample, then the respective cell(s) MAY be filled with the NULL value `n/a` or simply an empty string.
+- If information is unknown or a variable does not apply for a certain sample, then the respective cell(s) MAY be filled with `n/a` or simply an empty string.
 - The order of the samples (rows) in the `.janno` file MUST be equal to the order in the genetic data files (`.ind`, `.fam`) in the package.
 - The values in the columns **Poseidon_ID**, **Group_Name** and **Genetic_Sex** MUST be equal to the terms used in the genetic data files (`.ind`, `.fam`).
 - Multiple predefined columns of the `.janno` file are list columns that can hold multiple values (either strings or numerics) separated by `;`.
@@ -201,6 +201,6 @@ The `.ssf` file is another tab-separated text file with a header line. It stores
 - The link to the individuals listed in the `.janno`-file (and therefore to the entire Poseidon package) is made through a many-to-many foreign-key relationship between the .janno column `Poseidon_ID` and the .ssf column `poseidon_IDs`. That means each entry in the .janno file can be linked to many rows in the .ssf file and vice versa.
 - As in the `.janno` file arbitrary columns not defined here MAY be added to the `.ssf` file as long as their column names do not clash with the defined ones.
 - The order of columns and rows is irrelevant.
-- If information is unknown or a variable does not apply, then the respective cell(s) MAY be filled with the NULL value `n/a` or simply an empty string.
+- If information is unknown or a variable does not apply, then the respective cell(s) MAY be filled with `n/a` or simply an empty string.
 - Multiple predefined columns of the `.ssf` file are list columns that can hold multiple values (either strings or numerics) separated by `;`.
 - The decimal separator for all floating point numbers MUST be `.`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ All text files in the package MUST be UTF-8 encoded.
 The `POSEIDON.yml` file defines Poseidon packages by listing metainformation and relative paths in a standardised, machine-readable format.
 
 - It MUST be a valid [YAML file](https://yaml.org).
-- Its mandatory and optional fields are documented in the [POSEIDON_yml_fields.tsv file](https://github.com/poseidon-framework/poseidon-schema/blob/master/POSEIDON_yml_fields.tsv) in this repository.
+- Its mandatory and optional fields are documented in the [POSEIDON_yml_fields.tsv file](https://github.com/poseidon-framework/poseidon-schema/blob/master/POSEIDON_yml_fields.tsv).
 
 Here is an example for a `POSEIDON.yml` file:
 
@@ -141,8 +141,6 @@ The `.janno` file is a tab-separated text file with a header line. It holds cont
 - The values in the columns **Poseidon_ID**, **Group_Name** and **Genetic_Sex** MUST be equal to the terms used in the genetic data files (`.ind`, `.fam`).
 - Multiple predefined columns of the `.janno` file are list columns that can hold multiple values (either strings or numerics) separated by `;`.
 - The decimal separator for all floating point numbers MUST be `.`.
-
-For a more extensive documentation of the columns and their interaction see [https://poseidon-framework.github.io/#/janno_details](https://poseidon-framework.github.io/#/janno_details).
 
 ### The `.bib` file
 

--- a/janno_columns.tsv
+++ b/janno_columns.tsv
@@ -1,47 +1,47 @@
 janno_column_name	description	data_type	multi	choice	range	choice_options	range_lower	range_upper	mandatory	unique
-Poseidon_ID	id as defined by the genetics laboratory, needs to be unique (e.g. I1234, BOT001), needs to fit to the values in the poseidon package .fam file, if multiple datasets exist for the same individual different IDs are required (e.g. loschbour_snpAD)	String	FALSE	FALSE	FALSE				TRUE	TRUE
-Genetic_Sex	“F“, “M“ or “U“ because eigenstrat and plink formats only support these three, edge cases (XXY, XYY, X0) are undefined and should be grouped as F, M or U, with a note added	Char	FALSE	TRUE	FALSE	F;M;U			TRUE	FALSE
-Group_Name	ideally Eisenmann rule + underscore flags, e.g. to annotate relatives or outliers or low coverage, multiple entries separated by ; to accommodate different labels, value must equal the group name in the .fam file (in case of multiple entries the first one)	String	TRUE	FALSE	FALSE				TRUE	FALSE
-Alternative_IDs	other identifiers for the same individual, e.g. IDs in other databases or popular names (e.g. Ötzi/Iceman)	String	TRUE	FALSE	FALSE				FALSE	FALSE
-Relation_To	other individuals (by Poseidon_ID) that are related/identical to this individual, multiple entries separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE
+Poseidon_ID	sample identifier as defined by the genetics laboratory (e.g. I1234, BOT001), must fit to the values in the Poseidon package .fam/.ind file, must be unique within one package, if multiple datasets exist for the same individual different Poseidon_IDs are required	String	FALSE	FALSE	FALSE				TRUE	TRUE
+Genetic_Sex	genetic sex of the individual derived from this sample, only F, M or U because the EIGENSTRAT and PLINK formats only support these three, edge cases (e.g. XXY, XYY, X0) are undefined and should be grouped as F, M or U, with a Note added	Char	FALSE	TRUE	FALSE	F;M;U			TRUE	FALSE
+Group_Name	meaningful population/group identifiers for the sample, should follow the geographic-temporal nomenclature proposed by Eisenmann et al. 2018 (https://doi.org/10.1038/s41598-018-31123-z), multiple entries separated by ;, the first value must be equal the group name in the .fam/.ind file	String	TRUE	FALSE	FALSE				TRUE	FALSE
+Alternative_IDs	alternative identifiers for the same sampled individual, e.g. IDs in other databases or popular names like Ötzi/Iceman	String	TRUE	FALSE	FALSE				FALSE	FALSE
+Relation_To	other samples (by Poseidon_ID) that are related/identical to this sample, multiple entries separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE
 Relation_Degree	relationship degree for relatives mentioned in Related_To, multiple values separated by ; in the same order as Related_To in case of multiple relations	String	TRUE	TRUE	FALSE	identical;first;second;thirdToFifth;sixthToTenth;unrelated;other			FALSE	FALSE
-Relation_Type	relationship type for relatives mentioned in Related_To as an arbitrary string (e.g. sister_of, child_of, nephew_of, ...), multiple values separated by ; in the same order as Related_To in case of multiple relations	String	TRUE	FALSE	FALSE				FALSE	FALSE
-Relation_Note	arbitrary comments about the relations of this individual	String	FALSE	FALSE	FALSE				FALSE	FALSE
-Collection_ID	id as defined by the provider/owner of a sample (e.g. grave 40 skeleton 2)	String	FALSE	FALSE	FALSE				FALSE	FALSE
-Country	present-day political country	String	FALSE	FALSE	FALSE				FALSE	FALSE
+Relation_Type	relationship type for relatives mentioned in Related_To (e.g. sister_of, child_of, nephew_of), multiple values separated by ; in the same order as Related_To in case of multiple relations	String	TRUE	FALSE	FALSE				FALSE	FALSE
+Relation_Note	arbitrary comments about the genetic relationships of the sampled individual	String	FALSE	FALSE	FALSE				FALSE	FALSE
+Collection_ID	alternative sample identifier shared by the provider/owner of the sample (e.g. grave 40 skeleton 2)	String	FALSE	FALSE	FALSE				FALSE	FALSE
+Country	present-day political country of origin for the sample	String	FALSE	FALSE	FALSE				FALSE	FALSE
 Country_ISO	present-day political country expressed in ISO 3166-1 alpha-2 country codes	String	FALSE	FALSE	FALSE				FALSE	FALSE
-Location	unspecified location information like administrative or topographic region or mountains/rivers/lakes/cities nearby	String	FALSE	FALSE	FALSE				FALSE	FALSE
-Site	site name	String	FALSE	FALSE	FALSE				FALSE	FALSE
-Latitude	latitude with up to 5 places after the decimal point	Float	FALSE	FALSE	TRUE		-90	90	FALSE	FALSE
+Location	unspecified location information for the sample, e.g. administrative or topographic region or mountains/rivers/lakes/cities nearby	String	FALSE	FALSE	FALSE				FALSE	FALSE
+Site	name of the archaeological site where the sample was found	String	FALSE	FALSE	FALSE				FALSE	FALSE
+Latitude	latitude where the sample was found with up to 5 places after the decimal point	Float	FALSE	FALSE	TRUE		-90	90	FALSE	FALSE
 Longitude	longitude with up to 5 places after the decimal point	Float	FALSE	FALSE	TRUE		-180	180	FALSE	FALSE
-Date_Type	“C14“ if there is a set of radiocarbon dates in the columns Date_C14_Labnr, Date_C14_Uncal_BP and Date_C14_Uncal_BP_Err whose post-calibration probability distribution is a meaningful prior for the individual’s year of death, “contextual“ for any other age information only given in Date_BC_AD_Start, Date_BC_AD_Median and Date_BC_AD_Stop, “modern” for present-day individuals	String	FALSE	TRUE	FALSE	C14;contextual;modern			FALSE	FALSE
-Date_C14_Labnr	labnr of C14 date, multiple values separated by ; in case of multiple dates	String	TRUE	FALSE	FALSE				FALSE	FALSE
-Date_C14_Uncal_BP	uncalibrated years BP (as in before 1950AD), as reported by C14 labs, multiple values separated by ; in the same order as Date_C14_Labnr in case of multiple dates, only relevant if Date_Type is “C14”	Integer	TRUE	FALSE	TRUE		0	Inf	FALSE	FALSE
-Date_C14_Uncal_BP_Err	standard deviation (1 sigma ±), as reported by C14 labs, multiple values separated by ; in the same order as Date_C14_Labnr in case of multiple dates, only relevant if Date_Type is “C14”	Integer	TRUE	FALSE	TRUE		0	Inf	FALSE	FALSE
-Date_BC_AD_Start	lower (older) bound for the age, negative numbers for BC, positive numbers for AD, in case of C14 dates 95% interval post calibration, 2000 for modern samples	Integer	FALSE	FALSE	TRUE		-Inf	2050	FALSE	FALSE
-Date_BC_AD_Median	calibrated median age for C14 dates, or simple mid-points for archaeological intervals, 2000 for modern samples	Integer	FALSE	FALSE	TRUE		-Inf	2050	FALSE	FALSE
-Date_BC_AD_Stop	upper (more recent) bound for the age, negative numbers for BC, positive numbers for AD, in case of C14 dates 95% interval post calibration, 2000 for modern samples	Integer	FALSE	FALSE	TRUE		-Inf	2050	FALSE	FALSE
-Date_Note	a free text field for arbitrary comments about the dating information	String	FALSE	FALSE	FALSE				FALSE	FALSE
-MT_Haplogroup	mitochondrial haplogroup after phylotree.org as reported by Haplofind or Haplogrep	String	FALSE	FALSE	FALSE				FALSE	FALSE
-Y_Haplogroup	Y-chromosome haplogroup reported as published, for internal data, please follow syntax with main branch + most terminal derived Y-SNP (e.g. R1b-P312)	String	FALSE	FALSE	FALSE				FALSE	FALSE
-Source_Tissue	skeletal/tissue/source elements, specific bone name should be reported with an underscore (e.g. bone_phalanx), multiple values separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE
-Nr_Libraries	number of libraries	Integer	FALSE	FALSE	FALSE				FALSE	FALSE
-Library_Names	identifiers of the libraries used to generate the genotype data, multiple values separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE
-Capture_Type	specifics of data generation method, multiple values separated by ;	String	TRUE	TRUE	FALSE	Shotgun;1240K;ArborComplete;ArborPrimePlus;ArborAncestralPlus;TwistAncientDNA;OtherCapture;ReferenceGenome			FALSE	FALSE
-UDG 	UDG treatment, “mixed” in case multiple libraries with different UDG treatment were merged	String	FALSE	TRUE	FALSE	minus;half;plus;mixed			FALSE	FALSE
-Library_Built	strandedness, “mixed” in case multiple libraries with different protocols were merged	String	FALSE	TRUE	FALSE	ds;ss;mixed			FALSE	FALSE
-Genotype_Ploidy	ploidy of the genotypes	String	FALSE	TRUE	FALSE	diploid;haploid			FALSE	FALSE
-Data_Preparation_Pipeline_URL	URL pointing to a description of the pipeline used to generate the genotype data from the source data	String	FALSE	FALSE	FALSE				FALSE	FALSE
-Endogenous	% endogenous DNA as estimated from SG libraries (before capture), as for example estimated by EAGER, not on target and no quality filter, in case of multiple libraries report only the highest value	Float	FALSE	FALSE	TRUE		0	100	FALSE	FALSE
-Nr_SNPs	number of SNPs covered	Integer	FALSE	FALSE	FALSE				FALSE	FALSE
-Coverage_on_Target_SNPs	average X-fold coverage across targeted SNP sites after quality filtering (internal data)	Float	FALSE	FALSE	FALSE				FALSE	FALSE
-Damage	% damage on 5' end for the main shotgun library used for sequencing and/or capture, in case of multiple libraries report a value from the merged read alignment	Float	FALSE	FALSE	TRUE		0	100	FALSE	FALSE
-Contamination	(modern) contamination as measured by the method in Contamination_Meas, multiple values can be separated by ; (for different methods! In case of multiple libraries report a value from the merged read alignment), Contamination, Contamination_Err and Contamination_Meas must have the same number and order of (non-n/a) entries	String	TRUE	FALSE	FALSE				FALSE	FALSE
-Contamination_Err	(modern) contamination estimate error	String	TRUE	FALSE	FALSE				FALSE	FALSE
+Date_Type	type of dating information available for the sample, C14 if there is a set of radiocarbon dates in the columns Date_C14_Labnr, Date_C14_Uncal_BP and Date_C14_Uncal_BP_Err whose post-calibration probability distribution is a meaningful prior for the individual’s year of death, contextual for any other age information only given in Date_BC_AD_Start, Date_BC_AD_Median and Date_BC_AD_Stop, “modern” for present-day individuals	String	FALSE	TRUE	FALSE	C14;contextual;modern			FALSE	FALSE
+Date_C14_Labnr	lab numbers of C14 ages, multiple values separated by ; in case of multiple dates	String	TRUE	FALSE	FALSE				FALSE	FALSE
+Date_C14_Uncal_BP	uncalibrated years BP (as in before 1950AD) for the C14 ages as reported by C14 labs, multiple values separated by ; in the same order as Date_C14_Labnr in case of multiple dates, only relevant if Date_Type is C14	Integer	TRUE	FALSE	TRUE		0	Inf	FALSE	FALSE
+Date_C14_Uncal_BP_Err	standard deviation (1-sigma ±) for the uncalibrated C14 ages as reported by the C14 labs, multiple values separated by ; in the same order as Date_C14_Labnr in case of multiple dates, only relevant if Date_Type is C14	Integer	TRUE	FALSE	TRUE		0	Inf	FALSE	FALSE
+Date_BC_AD_Start	lower (older) bound for the age of the sample in years BC/AD, negative numbers for BC, positive numbers for AD, in case of C14 dates 2-sigma post calibration interval, 2000 for modern samples	Integer	FALSE	FALSE	TRUE		-Inf	2050	FALSE	FALSE
+Date_BC_AD_Median	median age of the sample in years BC/AD, for C14-dated samples median, for contextually dated samples simple mid-point of the archaeological intervals, 2000 for modern samples	Integer	FALSE	FALSE	TRUE		-Inf	2050	FALSE	FALSE
+Date_BC_AD_Stop	upper (more recent) bound for the age of the sample in years BC/AD, counter point to Date_BC_AD_Start	Integer	FALSE	FALSE	TRUE		-Inf	2050	FALSE	FALSE
+Date_Note	arbitrary comments about the dating information for the sample	String	FALSE	FALSE	FALSE				FALSE	FALSE
+MT_Haplogroup	mitochondrial haplogroup derived for the sample as specified on phylotree.org and as reported by the Haplofind or Haplogrep software tools	String	FALSE	FALSE	FALSE				FALSE	FALSE
+Y_Haplogroup	Y-chromosome haplogroup derived for the sample following a syntax with the main branch + the most terminal derived Y-SNP (e.g. R1b-P312)	String	FALSE	FALSE	FALSE				FALSE	FALSE
+Source_Tissue	skeletal element, tissue or other material sampled, the specific bone should be reported after an underscore (e.g. bone_phalanx), multiple values separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE
+Nr_Libraries	number of libraries produced for the sample	Integer	FALSE	FALSE	FALSE				FALSE	FALSE
+Library_Names	identifiers of the libraries used to generate the genotype data for the sample, multiple values separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE
+Capture_Type	specifics of the data generation method (e.g. capture method) for the individual libraries generated for the sample, multiple values separated by ;	String	TRUE	TRUE	FALSE	Shotgun;1240K;ArborComplete;ArborPrimePlus;ArborAncestralPlus;TwistAncientDNA;OtherCapture;ReferenceGenome			FALSE	FALSE
+UDG 	udg treatment for the libraries, mixed in case multiple libraries with different UDG treatment were merged	String	FALSE	TRUE	FALSE	minus;half;plus;mixed			FALSE	FALSE
+Library_Built	strandedness of the libraries, “mixed” in case multiple libraries with different protocols were merged	String	FALSE	TRUE	FALSE	ds;ss;mixed			FALSE	FALSE
+Genotype_Ploidy	ploidy of the genotypes for the sample	String	FALSE	TRUE	FALSE	diploid;haploid			FALSE	FALSE
+Data_Preparation_Pipeline_URL	url pointing to a description of the computational pipeline used to generate the genotype data from the source data	String	FALSE	FALSE	FALSE				FALSE	FALSE
+Endogenous	% endogenous DNA as estimated from SG libraries (before capture) as for example estimated by EAGER, not on target and no quality filter, in case of multiple libraries only the highest values should be reported	Float	FALSE	FALSE	TRUE		0	100	FALSE	FALSE
+Nr_SNPs	number of non-missing SNPs for the sample, counted on the SNP-set stored in the Poseidon package	Integer	FALSE	FALSE	FALSE				FALSE	FALSE
+Coverage_on_Target_SNPs	average X-fold coverage across targeted SNP sites after quality filtering	Float	FALSE	FALSE	FALSE				FALSE	FALSE
+Damage	% damage on the 5' end for the main shotgun library used for sequencing and/or capture, in case of multiple libraries a value from the merged read alignment should be reported	Float	FALSE	FALSE	TRUE		0	100	FALSE	FALSE
+Contamination	(modern) contamination of the sample as measured by the method in Contamination_Meas, multiple values separated by ; (for different methods, in case of multiple libraries report a value from the merged read alignment), the variables Contamination, Contamination_Err and Contamination_Meas must have the same number and order of (non-n/a) entries	String	TRUE	FALSE	FALSE				FALSE	FALSE
+Contamination_Err	(modern) contamination estimate error of the sample	String	TRUE	FALSE	FALSE				FALSE	FALSE
 Contamination_Meas	method to measure contamination, should be a software tool (ANGSD, Schmutzi, …) and the respective software versions, details should go to Contamination_Note	String	TRUE	FALSE	FALSE				FALSE	FALSE
-Contamination_Note	arbitrary comments about the contamination estimate	String	FALSE	FALSE	FALSE				FALSE	FALSE
-Genetic_Source_Accession_IDs	ENA or SRA Accession ID(s) pointing to the source data used to generate the genotyping data, if multiple are given they should be arranged by descending specificity (e.g. project id > sample id > sequencing run id)	String	TRUE	FALSE	FALSE				FALSE	FALSE
-Primary_Contact	Project lead or first author	String	FALSE	FALSE	FALSE				FALSE	FALSE
-Publication	bibtex key (e.g. “AuthorJournalYear“) or “unpublished“	String	TRUE	FALSE	FALSE				FALSE	FALSE
-Note	wildcard comments, e.g. note down aneuploidies here	String	FALSE	FALSE	FALSE				FALSE	FALSE
-Keywords	arbitrary tags separated by ; (e.g. for custom sorting purposes) 	String	TRUE	FALSE	FALSE				FALSE	FALSE
+Contamination_Note	arbitrary comments about the contamination estimation	String	FALSE	FALSE	FALSE				FALSE	FALSE
+Genetic_Source_Accession_IDs	ENA or SRA accession identifiers pointing to the source data used to generate the genotyping data for the sample, multiple values separated by ;, if multiple are given they should be arranged by descending specificity (e.g. project id > sample id > sequencing run id)	String	TRUE	FALSE	FALSE				FALSE	FALSE
+Primary_Contact	project lead or first author who generated and published the data for the sample	String	FALSE	FALSE	FALSE				FALSE	FALSE
+Publication	bibtex keys for the publications where a sample was published (e.g. “AuthorJournalYear“) or “unpublished“, multiple values separated by ;, all must be present with complete BibTeX entries in the Poseidon package’s .bib file	String	TRUE	FALSE	FALSE				FALSE	FALSE
+Note	arbitrary comments about the sample	String	FALSE	FALSE	FALSE				FALSE	FALSE
+Keywords	arbitrary tags, multiple values separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE

--- a/ssf_columns.tsv
+++ b/ssf_columns.tsv
@@ -1,23 +1,23 @@
 sequencingSourceFile_column_name	description	data_type	multi	choice	range	choice_options	range_lower	range_upper	mandatory	unique
-poseidon_IDs	The Poseidon_IDs this sequencing entity corresponds to, from the Janno-file, multiple entries separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE
-udg	The kind of UDG treatment applied to the library for this sequencing entity	String	FALSE	TRUE	FALSE	minus;half;plus			FALSE	FALSE
-library_built	The library preparation method applied for this sequencing entity (single- or double-stranded)	String	FALSE	TRUE	FALSE	ds;ss			FALSE	FALSE
-sample_accession	The sample accession code as used in INSDC databases, including ENA and SRA (Example: SAMEA7050454)	String	FALSE	FALSE	FALSE				FALSE	FALSE
-study_accession	The study accession code as used in INSDC databases, including ENA and SRA (Example: PRJEB39316)	String	FALSE	FALSE	FALSE				FALSE	FALSE
-run_accession	The run accession code as used in INSDC databases, including ENA and SRA (Example: ERR4331996). This should be a unique identifier in most cases	String	FALSE	FALSE	FALSE				FALSE	FALSE
-sample_alias	The sample alias defined by the submitter	String	FALSE	FALSE	FALSE				FALSE	FALSE
-secondary_sample_accession	A secondary sample accession, as used at the ENA for historical reasons (Example: ERS4811084)	String	FALSE	FALSE	FALSE				FALSE	FALSE
-first_public	The date (YYYY-MM-DD) this sample was first made public	Date	FALSE	FALSE	FALSE				FALSE	FALSE
-last_updated	The date (YYYY-MM-DD) this sample was last updated	Date	FALSE	FALSE	FALSE				FALSE	FALSE
-instrument_model	The name of the instrument used (Example: Illumina HiSeq 2500)	String	FALSE	FALSE	FALSE				FALSE	FALSE
-library_layout	The library layout of the sequencing entity (Example: SINGLE)	String	FALSE	FALSE	FALSE				FALSE	FALSE
-library_source	The source of the DNA library (Example: GENOMIC)	String	FALSE	FALSE	FALSE				FALSE	FALSE
-instrument_platform	The platform brand or type of the sequencer (Example: ILLUMINA)	String	FALSE	FALSE	FALSE				FALSE	FALSE
-library_name	The ID of the library. Defaults to the library name the submitter has entered to the raw sequencing data repository. Data entries across which optical duplicates could exist should have matching library names. Can sometimes be useful to figure out which Poseidon_ID this entity belongs to.	String	FALSE	FALSE	FALSE				FALSE	FALSE
-library_strategy	The strategy used to create the library (Example: WGS)	String	FALSE	FALSE	FALSE				FALSE	FALSE
-fastq_ftp	The FTP-link(s) (URL) to the FASTQ file(s) (Example: ftp.sra.ebi.ac.uk/vol1/fastq/ERR433/009/ERR4332639/ERR4332639.fastq.gz)	URL	TRUE	FALSE	FALSE				FALSE	FALSE
-fastq_aspera	The Aspera-link (URL) to the FASTQ-file(s). (Example: fasp.sra.ebi.ac.uk:/vol1/fastq/ERR433/009/ERR4332639/ERR4332639.fastq.gz)	URL	TRUE	FALSE	FALSE				FALSE	FALSE
-fastq_bytes	The number of bytes of the FASTQ-file(s) in bytes	Integer	TRUE	FALSE	TRUE		0	Inf	FALSE	FALSE
-fastq_md5	The MD5 hash(es) of the FASTQ-file(s)	String	TRUE	FALSE	FALSE				FALSE	FALSE
-read_count	The number of reads	Integer	FALSE	FALSE	TRUE		0	Inf	FALSE	FALSE
-submitted_ftp	The URL(s) to the originally submitted file(s) before it got converted to FASTQ. This can sometimes be helpful for processing	String	TRUE	FALSE	FALSE				FALSE	FALSE
+poseidon_IDs	Poseidon_IDs (in the .janno file) the sequencing entity corresponds to, multiple entries separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE
+udg	udg treatment applied to the library for the sequencing entity	String	FALSE	TRUE	FALSE	minus;half;plus			FALSE	FALSE
+library_built	library preparation method applied for the sequencing entity (single- or double-stranded)	String	FALSE	TRUE	FALSE	ds;ss			FALSE	FALSE
+sample_accession	sample accession code as used in the INSDC databases (including ENA and SRA) to identify the sequencing entity (e.g. SAMEA7050454)	String	FALSE	FALSE	FALSE				FALSE	FALSE
+study_accession	study accession code as used in the INSDC databases (e.g. PRJEB39316)	String	FALSE	FALSE	FALSE				FALSE	FALSE
+run_accession	run accession code as used in the INSDC databases (e.g. ERR4331996), this should be a unique identifier in a Poseidon package	String	FALSE	FALSE	FALSE				FALSE	FALSE
+sample_alias	sample alias defined by the submitter in the raw sequencing data repository	String	FALSE	FALSE	FALSE				FALSE	FALSE
+secondary_sample_accession	a secondary sample accession, used in the ENA database for historical reasons (e.g. ERS4811084)	String	FALSE	FALSE	FALSE				FALSE	FALSE
+first_public	date (YYYY-MM-DD) the sequencing entity was first made public in the raw sequencing data repository	Date	FALSE	FALSE	FALSE				FALSE	FALSE
+last_updated	date (YYYY-MM-DD) the sequencing entity was last updated in the raw sequencing data repository	Date	FALSE	FALSE	FALSE				FALSE	FALSE
+instrument_model	name of the instrument used to process the sequencing entity (e.g. Illumina HiSeq 2500)	String	FALSE	FALSE	FALSE				FALSE	FALSE
+library_layout	library layout of the sequencing entity (e.g. SINGLE)	String	FALSE	FALSE	FALSE				FALSE	FALSE
+library_source	source of the DNA library (e.g. GENOMIC)	String	FALSE	FALSE	FALSE				FALSE	FALSE
+instrument_platform	platform, brand or type of the sequencer (e.g. ILLUMINA)	String	FALSE	FALSE	FALSE				FALSE	FALSE
+library_name	library identifier, so library name the submitter has entered to the raw sequencing data repository, data entries across which optical duplicates could exist should have matching library names	String	FALSE	FALSE	FALSE				FALSE	FALSE
+library_strategy	strategy used to create the library for the sequencing entity (e.g. WGS)	String	FALSE	FALSE	FALSE				FALSE	FALSE
+fastq_ftp	ftp links to the FASTQ files for the sequencing entity in the raw sequencing data repository (e.g. ftp.sra.ebi.ac.uk/vol1/fastq/ERR433/009/ ERR4332639/ERR4332639.fastq.gz), multiple entries separated by ;	URL	TRUE	FALSE	FALSE				FALSE	FALSE
+fastq_aspera	aspera links to the FASTQ files for the sequencing entity in the raw sequencing data repository (e.g. fasp.sra.ebi.ac.uk:/vol1/fastq/ERR433/009/ ERR4332639/ERR4332639.fastq.gz), multiple entries separated by ;	URL	TRUE	FALSE	FALSE				FALSE	FALSE
+fastq_bytes	number of bytes in the FASTQ files, multiple entries separated by ;, must be in the same order as the ftp and/or aspera links	Integer	TRUE	FALSE	TRUE		0	Inf	FALSE	FALSE
+fastq_md5	md5 hashes of the FASTQ files, multiple entries separated by ;, must be in the same order as the ftp and/or aspera links	String	TRUE	FALSE	FALSE				FALSE	FALSE
+read_count	number of reads in the sequencing entity	Integer	FALSE	FALSE	TRUE		0	Inf	FALSE	FALSE
+submitted_ftp	urls to the originally submitted files before they got converted to FASTQ in the INSDC databases, multiple entries separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE


### PR DESCRIPTION
Creating the PDF in #71 helped me find some rough edges of the schema text. I will collect my suggestions in this PR and ask for review later.

The first change I made was to make the schema compliant with [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119), as suggested by @TCLamnidis. It's a tiny change, but helps to clarify the expressions we used so far.