### PR TITLE
Update SSF column specification.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,7 @@
 - Made the `Collection_ID` column a list column that allows multiple entries separated by `;`.
 - Adjusted the definition of the `Group_Name` column. The role of population labels as general analysis labels was emphasised, and the original recommendation for the geographic-temporal nomenclature proposed by Eisenmann et al. 2018 toned down.
 
-#### Changes to the `.janno` file
+#### Changes to the `.ssf` file
 
 ##### Added columns
 

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,12 @@
 - Made the `Collection_ID` column a list column that allows multiple entries separated by `;`.
 - Adjusted the definition of the `Group_Name` column. The role of population labels as general analysis labels was emphasised, and the original recommendation for the geographic-temporal nomenclature proposed by Eisenmann et al. 2018 toned down.
 
+#### Changes to the `.janno` file
+
+##### Added columns
+
+- Added a `submitted_md5` column, which records the md5sum of the file in the `submitted_ftp` column.
+
 ### 2.7.0 -> 2.7.1 [not breaking]
 
 Only changes to the definition of the Sequencing Source File (`.ssf`):

--- a/ssf_columns.tsv
+++ b/ssf_columns.tsv
@@ -21,3 +21,4 @@ fastq_bytes	number of bytes in the FASTQ files, multiple entries separated by ;,
 fastq_md5	md5 hashes of the FASTQ files, multiple entries separated by ;, must be in the same order as the ftp and/or aspera links	String	TRUE	FALSE	FALSE				FALSE	FALSE
 read_count	number of reads in the sequencing entity	Integer	FALSE	FALSE	TRUE		0	Inf	FALSE	FALSE
 submitted_ftp	urls to the originally submitted files before they got converted to FASTQ in the INSDC databases, multiple entries separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE
+submitted_md5	md5 hashes of the originally submitted files before they got converted to FASTQ in the INSDC databases, multiple entries separated by ;	String	TRUE	FALSE	FALSE				FALSE	FALSE


### PR DESCRIPTION
This minimal PR adds the `submitted_md5` column to the SSF schema. This column is useful for validating the submitted file in case the FastQ conversion has failed for a submitted BAM file.