### PR TITLE
Added two POSEIDON.yml fields to specify a data licence for a package

### DIFF
--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -9,6 +9,8 @@ orcid	1	contributor	orcid of one contributor	String	ORCID	FALSE
 packageVersion	0		package version (should be changed/incremented when the package is changed)	String	X.Y.Z	TRUE
 lastModified	0		date of last modification of the package (should be updated when the package is changed)	Date	YYYY-MM-DD	FALSE
 genotypeData	0		genotype data section			TRUE
+licence	0		short name of data licence that applies for this package	String		FALSE
+licenceFile	0		relative path to a licence file	String	Path	FALSE
 referenceGenomeAssembly	1	genotypeData	reference genome name of the reference genome used, e.g. GRCh37	String		FALSE
 referenceGenomeAssemblyURL	1	genotypeData	reference assembly accession URL from a public database, such as NCBI or Ensembl	String	URL	FALSE
 format	1	genotypeData	genotype data file format	String	EIGENSTRAT;PLINK;VCF	TRUE

--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -8,9 +8,10 @@ email	1	contributor	email of one contributor	String	Email	TRUE
 orcid	1	contributor	orcid of one contributor	String	ORCID	FALSE
 packageVersion	0		package version (should be changed/incremented when the package is changed)	String	X.Y.Z	TRUE
 lastModified	0		date of last modification of the package (should be updated when the package is changed)	Date	YYYY-MM-DD	FALSE
+licence	0		data licence section			FALSE
+name	1	licence	short name of data licence that applies for this package, usually a Creative Commons licence	String		FALSE
+file	1	licence	relative path to a licence file (usually not necessary, the name is sufficient for standard licences)	String	Path	FALSE
 genotypeData	0		genotype data section			TRUE
-licence	0		short name of data licence that applies for this package	String		FALSE
-licenceFile	0		relative path to a licence file	String	Path	FALSE
 referenceGenomeAssembly	1	genotypeData	reference genome name of the reference genome used, e.g. GRCh37	String		FALSE
 referenceGenomeAssemblyURL	1	genotypeData	reference assembly accession URL from a public database, such as NCBI or Ensembl	String	URL	FALSE
 format	1	genotypeData	genotype data file format	String	EIGENSTRAT;PLINK;VCF	TRUE

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ contributor:
     email: paul.panther@example.edu
 packageVersion: 1.1.2
 lastModified: 2021-01-28
+licence: CC BY-SA 4.0
+licenceFile: LICENCE.md
 genotypeData:
   format: PLINK
   genoFile: Switzerland_LNBA_Roswita.bed
@@ -134,6 +136,18 @@ Each version number is comprised of three numbers, separated by a `.`. For examp
 When the `packageVersion` is changed, then the `lastModified` date MUST be updated and an entry to the `CHANGELOG.md` file SHOULD be added summarising the changes made.
 
 Packages SHOULD start at `packageVersion` `0.1.0`.
+
+### Data licensing and the LICENSE.md file
+
+Data licences are a common way to grant the public permission to use a dataset under copyright law.
+
+Poseidon packages MAY specify a licence, and if so, SHOULD use [Creative Commons licences](https://creativecommons.org/share-your-work/cclicenses).
+
+Licences are documented in the `POSEIDON.yml` file in the `licence` field, or with a `licenceFile`, or with both the `licence` field and a `licenceFile`. `licence` SHOULD include a short string with name and version of the licence, e.g. `CC BY-SA 4.0` The `licenceFile`, typically named `LICENSE.md`, SHOULD include the full text of a licence, or a short notifier further contextualizing the entry in the `licence` field. For example:
+
+```default
+The Poseidon package Switzerland_LNBA_Roswita © 2021 by Roswita Malone is licensed under Creative Commons Attribution-ShareAlike 4.0 International. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
+```
 
 ### Genotype data
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ contributor:
     email: paul.panther@example.edu
 packageVersion: 1.1.2
 lastModified: 2021-01-28
-licence: CC BY-SA 4.0
-licenceFile: LICENCE.md
+licence:
+  name: CC BY 4.0
+  file: LICENCE.md
 genotypeData:
   format: PLINK
   genoFile: Switzerland_LNBA_Roswita.bed
@@ -143,10 +144,10 @@ Data licences are a common way to grant the public permission to use a dataset u
 
 Poseidon packages MAY specify a licence, and if so, SHOULD use [Creative Commons licences](https://creativecommons.org/share-your-work/cclicenses).
 
-Licences are documented in the `POSEIDON.yml` file in the `licence` field, or with a `licenceFile`, or with both the `licence` field and a `licenceFile`. `licence` SHOULD include a short string with name and version of the licence, e.g. `CC BY-SA 4.0` The `licenceFile`, typically named `LICENCE.md`, SHOULD include the full text of a licence, or a short notifier further contextualizing the entry in the `licence` field. For example:
+Licences are documented in the `POSEIDON.yml` file in the `licence` section, either with just the `name`, or with a licence `file`, or with both the `name` and a `file`. `name` SHOULD include a short string with name and version of the licence, e.g. `CC BY 4.0`. The `file`, typically named `LICENCE.md`, MAY include the full text of a licence, or a short notifier further contextualizing the entry in the `name` field. For example:
 
 ```default
-The Poseidon package Switzerland_LNBA_Roswita © 2021 by Roswita Malone is licensed under Creative Commons Attribution-ShareAlike 4.0 International. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
+The Poseidon package Switzerland_LNBA_Roswita © 2021 by Roswita Malone is licensed under Creative Commons Attribution 4.0 International. To view a copy of this license, visit https://creativecommons.org/licenses/by/4.0/
 ```
 
 ### Genotype data

--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ When the `packageVersion` is changed, then the `lastModified` date MUST be updat
 
 Packages SHOULD start at `packageVersion` `0.1.0`.
 
-### Data licensing and the LICENSE.md file
+### Data licensing and the LICENCE.md file
 
 Data licences are a common way to grant the public permission to use a dataset under copyright law.
 
 Poseidon packages MAY specify a licence, and if so, SHOULD use [Creative Commons licences](https://creativecommons.org/share-your-work/cclicenses).
 
-Licences are documented in the `POSEIDON.yml` file in the `licence` field, or with a `licenceFile`, or with both the `licence` field and a `licenceFile`. `licence` SHOULD include a short string with name and version of the licence, e.g. `CC BY-SA 4.0` The `licenceFile`, typically named `LICENSE.md`, SHOULD include the full text of a licence, or a short notifier further contextualizing the entry in the `licence` field. For example:
+Licences are documented in the `POSEIDON.yml` file in the `licence` field, or with a `licenceFile`, or with both the `licence` field and a `licenceFile`. `licence` SHOULD include a short string with name and version of the licence, e.g. `CC BY-SA 4.0` The `licenceFile`, typically named `LICENCE.md`, SHOULD include the full text of a licence, or a short notifier further contextualizing the entry in the `licence` field. For example:
 
 ```default
 The Poseidon package Switzerland_LNBA_Roswita © 2021 by Roswita Malone is licensed under Creative Commons Attribution-ShareAlike 4.0 International. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/

--- a/changelog.md
+++ b/changelog.md
@@ -16,11 +16,11 @@
 
 #### Changes to the `POSEIDON.yml` file
 
+- Added the optional section `licence` with the fields `name` and `file` to specify a data licence for a package.
 - Added two optional fields within the `genotypeData` structure:
   - `referenceGenomeAssembly`, the reference genome name of the reference genome used, e.g. GRCh37
   - `referenceGenomeAssemblyURL`, the reference assembly accession URL from a public database, such as NCBI or Ensembl
 - Modified the definition of the `genoFile` and `snpFile` fields to cover the case of gzipped data, for which the respective file names must end with `*.gz`.
-- Added the optional fields `licence` and `licenceFile` to encode a data licence for a package.
 
 #### Changes to the `.janno` file
 

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
   - `referenceGenomeAssembly`, the reference genome name of the reference genome used, e.g. GRCh37
   - `referenceGenomeAssemblyURL`, the reference assembly accession URL from a public database, such as NCBI or Ensembl
 - Modified the definition of the `genoFile` and `snpFile` fields to cover the case of gzipped data, for which the respective file names must end with `*.gz`.
+- Added the optional fields `licence` and `licenceFile` to encode a data licence for a package.
 
 #### Changes to the `.janno` file
 


### PR DESCRIPTION
I think it was @martynamolak who proposed this initially and I think it is a good feature to have. I tried to make it pretty flexible and, of course, fully optional.

The british spelling of "licence" nauseates me a bit, but I guess we should stick to it for consistency.