### PR TITLE
Some updates to the license field

### DIFF
--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -10,6 +10,7 @@ packageVersion	0		package version (should be changed/incremented when the packag
 lastModified	0		date of last modification of the package (should be updated when the package is changed)	Date	YYYY-MM-DD	FALSE
 license	0		data license section			FALSE
 name	1	license	short name of data license that applies for this package, usually a Creative Commons licence	String		TRUE
+url	1	license	URL to the license 	String	Path	TRUE
 file	1	license	relative path to a license file (usually not necessary, the name is sufficient for standard licenses)	String	Path	FALSE
 genotypeData	0		genotype data section			TRUE
 referenceGenomeAssembly	1	genotypeData	reference genome name of the reference genome used, e.g. GRCh37	String		FALSE

--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -9,7 +9,7 @@ orcid	1	contributor	orcid of one contributor	String	ORCID	FALSE
 packageVersion	0		package version (should be changed/incremented when the package is changed)	String	X.Y.Z	TRUE
 lastModified	0		date of last modification of the package (should be updated when the package is changed)	Date	YYYY-MM-DD	FALSE
 license	0		data license section			FALSE
-name	1	license	short name of data license that applies for this package, usually a Creative Commons licence	String		TRUE
+name	1	license	short name of data license that applies for this package, usually a Creative Commons license	String		TRUE
 url	1	license	URL to the license 	String	Path	TRUE
 file	1	license	relative path to a license file (usually not necessary, the name is sufficient for standard licenses)	String	Path	FALSE
 genotypeData	0		genotype data section			TRUE

--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -8,9 +8,9 @@ email	1	contributor	email of one contributor	String	Email	TRUE
 orcid	1	contributor	orcid of one contributor	String	ORCID	FALSE
 packageVersion	0		package version (should be changed/incremented when the package is changed)	String	X.Y.Z	TRUE
 lastModified	0		date of last modification of the package (should be updated when the package is changed)	Date	YYYY-MM-DD	FALSE
-licence	0		data licence section			FALSE
-name	1	licence	short name of data licence that applies for this package, usually a Creative Commons licence	String		TRUE
-file	1	licence	relative path to a licence file (usually not necessary, the name is sufficient for standard licences)	String	Path	FALSE
+license	0		data license section			FALSE
+name	1	license	short name of data license that applies for this package, usually a Creative Commons licence	String		TRUE
+file	1	license	relative path to a license file (usually not necessary, the name is sufficient for standard licenses)	String	Path	FALSE
 genotypeData	0		genotype data section			TRUE
 referenceGenomeAssembly	1	genotypeData	reference genome name of the reference genome used, e.g. GRCh37	String		FALSE
 referenceGenomeAssemblyURL	1	genotypeData	reference assembly accession URL from a public database, such as NCBI or Ensembl	String	URL	FALSE

--- a/POSEIDON_yml_fields.tsv
+++ b/POSEIDON_yml_fields.tsv
@@ -9,7 +9,7 @@ orcid	1	contributor	orcid of one contributor	String	ORCID	FALSE
 packageVersion	0		package version (should be changed/incremented when the package is changed)	String	X.Y.Z	TRUE
 lastModified	0		date of last modification of the package (should be updated when the package is changed)	Date	YYYY-MM-DD	FALSE
 licence	0		data licence section			FALSE
-name	1	licence	short name of data licence that applies for this package, usually a Creative Commons licence	String		FALSE
+name	1	licence	short name of data licence that applies for this package, usually a Creative Commons licence	String		TRUE
 file	1	licence	relative path to a licence file (usually not necessary, the name is sufficient for standard licences)	String	Path	FALSE
 genotypeData	0		genotype data section			TRUE
 referenceGenomeAssembly	1	genotypeData	reference genome name of the reference genome used, e.g. GRCh37	String		FALSE

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ contributor:
     email: paul.panther@example.edu
 packageVersion: 1.1.2
 lastModified: 2021-01-28
-licence:
+license:
   name: CC BY 4.0
-  file: LICENCE.md
+  file: license.md
 genotypeData:
   format: PLINK
   genoFile: Switzerland_LNBA_Roswita.bed
@@ -138,13 +138,13 @@ When the `packageVersion` is changed, then the `lastModified` date MUST be updat
 
 Packages SHOULD start at `packageVersion` `0.1.0`.
 
-### Data licensing and the LICENCE.md file
+### Data licensing and the license.md file
 
 Data licences are a common way to grant the public permission to use a dataset under copyright law.
 
-Poseidon packages MAY specify a licence, and if so, SHOULD use [Creative Commons licences](https://creativecommons.org/share-your-work/cclicenses).
+Poseidon packages MAY specify a license, and if so, SHOULD use [Creative Commons licences](https://creativecommons.org/share-your-work/cclicenses).
 
-Licences are documented in the `POSEIDON.yml` file in the `licence` section, either with just the `name`, or with a licence `file`, or with both the `name` and a `file`. `name` SHOULD include a short string with name and version of the licence, e.g. `CC BY 4.0`. The `file`, typically named `LICENCE.md`, MAY include the full text of a licence, or a short notifier further contextualizing the entry in the `name` field. For example:
+Licences are documented in the `POSEIDON.yml` file in the `license` section, either with just the `name`, or with a license `file`, or with both the `name` and a `file`. `name` SHOULD include a short string with name and version of the license, e.g. `CC BY 4.0`. The `file`, typically named `license.md`, MAY include the full text of a license, or a short notifier further contextualizing the entry in the `name` field. For example:
 
 ```default
 The Poseidon package Switzerland_LNBA_Roswita © 2021 by Roswita Malone is licensed under Creative Commons Attribution 4.0 International. To view a copy of this license, visit https://creativecommons.org/licenses/by/4.0/

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ packageVersion: 1.1.2
 lastModified: 2021-01-28
 license:
   name: CC BY 4.0
+  url: https://creativecommons.org/licenses/by/4.0/
   file: license.md
 genotypeData:
   format: PLINK

--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,7 @@
 
 #### Changes to the `POSEIDON.yml` file
 
-- Added the optional section `licence` with the fields `name` and `file` to specify a data licence for a package.
+- Added the optional section `license` with the fields `name` and `file` to specify a data license for a package.
 - Added two optional fields within the `genotypeData` structure:
   - `referenceGenomeAssembly`, the reference genome name of the reference genome used, e.g. GRCh37
   - `referenceGenomeAssemblyURL`, the reference assembly accession URL from a public database, such as NCBI or Ensembl


### PR DESCRIPTION
Right now, the new `license` field is not mandatory, which is of course correct. But _if_ it is given, then at least the name of the license should be mandatory. I'm not sure how to express this, but I propose to change the mandatory status of `name` to TRUE to indicate this. 